### PR TITLE
mcpat.py and periodic-power.py: fix path names of log files

### DIFF
--- a/common/scheduler/performance_counters.cc
+++ b/common/scheduler/performance_counters.cc
@@ -5,9 +5,24 @@
 
 using namespace std;
 
-PerformanceCounters::PerformanceCounters(std::string instPowerFileName, std::string instTemperatureFileName, std::string instCPIStackFileName)
-    : instPowerFileName(instPowerFileName), instTemperatureFileName(instTemperatureFileName), instCPIStackFileName(instCPIStackFileName) {
+PerformanceCounters::PerformanceCounters(const char* output_dir, std::string instPowerFileNameParam, std::string instTemperatureFileNameParam, std::string instCPIStackFileNameParam)
+    : instPowerFileName(instPowerFileNameParam), instTemperatureFileName(instTemperatureFileNameParam), instCPIStackFileName(instCPIStackFileNameParam) {
 
+	//gkothar1: fix log file path names
+	std::string temp = instPowerFileName;
+	instPowerFileName = std::string(output_dir);
+	instPowerFileName.append("/");
+	instPowerFileName.append(temp);
+
+	temp = instTemperatureFileName;
+	instTemperatureFileName = std::string(output_dir);
+	instTemperatureFileName.append("/");
+	instTemperatureFileName.append(temp);
+
+	temp = instCPIStackFileName;
+	instCPIStackFileName = std::string(output_dir);
+	instCPIStackFileName.append("/");
+	instCPIStackFileName.append(temp);
 }
 
 /** getPowerOfComponent

--- a/common/scheduler/performance_counters.h
+++ b/common/scheduler/performance_counters.h
@@ -11,7 +11,7 @@
 
 class PerformanceCounters {
 public:
-    PerformanceCounters(std::string instPowerFileName, std::string instTemperatureFileName, std::string instCPIStackFileName);
+    PerformanceCounters(const char* output_dir, std::string instPowerFileNameParam, std::string instTemperatureFileNameParam, std::string instCPIStackFileNameParam);
     double getPowerOfComponent (std::string component) const;
     double getPowerOfCore(int coreId) const;
     double getPeakTemperature () const;

--- a/common/scheduler/scheduler_open.cc
+++ b/common/scheduler/scheduler_open.cc
@@ -148,7 +148,8 @@ SchedulerOpen::SchedulerOpen(ThreadManager *thread_manager)
 	}
 
 
-	performanceCounters = new PerformanceCounters("InstantaneousPower.log", "InstantaneousTemperature.log", "InstantaneousCPIStack.log");
+	performanceCounters = new PerformanceCounters(Sim()->getCfg()->getString("general/output_dir").c_str(),
+		"InstantaneousPower.log", "InstantaneousTemperature.log", "InstantaneousCPIStack.log");
 
 	mappingEpoch = atol (Sim()->getCfg()->getString("scheduler/open/epoch").c_str());
 	queuePolicy = Sim()->getCfg()->getString("scheduler/open/queuePolicy").c_str();

--- a/scripts/periodic-power.py
+++ b/scripts/periodic-power.py
@@ -16,7 +16,7 @@ class StatTrace:
     filename = 'Temp'
 
     interval_ns = long(args.get(0, 100000))
-    with open("Interval.dat", 'w') as f:
+    with open(os.path.join(sim.config.output_dir, "Interval.dat"), 'w') as f:
       f.write(str(interval_ns))
 
     self.clean_files()
@@ -57,11 +57,12 @@ class StatTrace:
     sim.util.Every(interval_ns * sim.util.Time.NS, self.periodic, statsdelta = self.sd, roi_only = True)
     
   def clean_files(self):
-    for filename in ('PeriodicCPIStack.log',
-                     'PeriodicPower.log',
-                     'PeriodicThermal.log',
-                     'PeriodicFrequency.log',
-                     'PeriodicVdd.log',):
+    # gkothar1
+    for filename in (os.path.join(sim.config.output_dir, 'PeriodicCPIStack.log'),
+                     os.path.join(sim.config.output_dir, 'PeriodicPower.log'),
+                     os.path.join(sim.config.output_dir, 'PeriodicThermal.log'),
+                     os.path.join(sim.config.output_dir, 'PeriodicFrequency.log'),
+                     os.path.join(sim.config.output_dir, 'PeriodicVdd.log')):
       open(filename, 'w')  # empties the file
 
   def periodic(self, time, time_delta):


### PR DESCRIPTION
- This commit fixes the pathnames of all the log files generated during power/thermal simulations.
- With this, all the log files are created in the `config.output_dir`, as specified in the HotSniper config files.