### PR TITLE
Added fix for unsigned overflow in timeJump var

### DIFF
--- a/common/scheduler/scheduler_open.cc
+++ b/common/scheduler/scheduler_open.cc
@@ -926,7 +926,7 @@ void SchedulerOpen::threadExit(thread_id_t thread_id, SubsecondTime time) {
 		}
 		else if (numberOfTasksWaitingToSchedule () != 0) {
 
-			UInt64 timeJump = 0;
+			SInt64 timeJump = 0;
 
 			UInt64 nextArrivalTime = 0;
 			for (int taskIterator = 0; taskIterator < numberOfTasks; taskIterator++) {
@@ -942,6 +942,9 @@ void SchedulerOpen::threadExit(thread_id_t thread_id, SubsecondTime time) {
 			}
 
 			timeJump = nextArrivalTime - time.getNS();
+			if (timeJump < 0) {
+                cout << "\n[Scheduler]: Task arrival time in past, moving it forward to the current time with negative arrival time adjustment.\n";
+            }
 			cout << "\n[Scheduler]: Readjusting Arrival Time by " << timeJump << " ns \n"; // This will not effect the result of response time as arrival time of all unscheduled tasks are adjusted relatively.
 
 			for (int taskIterator = 0; taskIterator < numberOfTasks; taskIterator++) {


### PR DESCRIPTION
If a task finishes and there are no tasks to schedule an offset is calculated to move the arrival times of *all* tasks forward. The offset is set so the earliest task can start running immediately.

There is an edge condition where SchedulerOpen::threadExit() is run because a task finished and the earliest task to run has an arrival time that smaller than the current time. So it should have already been scheduled but the scheduler has not run yet. For example:

current time             336863
next_task_arrival_time   200000
scheduling epoch       10000000

This causes the unsigned timeJump to be come negative and thus overflow. The adjustment results are still correct and unsigned values can overflow so this is well-defined. But the log file will print a large postive value instead of the correct negative one:

[Scheduler]: Readjusting Arrival Time by 18446744073709414753 ns

The fix it to make timeJump signed. It will then print:

[Scheduler]: Task arrival time in past, moving it to current time with negative arrival time adjustment.
[Scheduler]: Readjusting Arrival Time by -136863 ns